### PR TITLE
Conditionally import `process` for node 0.10 compatibility

### DIFF
--- a/src/dtsCreator.js
+++ b/src/dtsCreator.js
@@ -1,6 +1,8 @@
 'use strict';
 
-import process from 'process';
+if (!process) {
+  const process = require('process');
+}
 import fs from 'fs';
 import path from'path';
 


### PR DESCRIPTION
I'm trying to use the `typed-css-modules` package in a node 0.10 environment -- everything here works except the import of the `process` builtin module, which doesn't exist in node 0.10 (`process` is an ambient global).

@Quramy: Does this seem reasonable to you?
