### PR TITLE
Add drop extension support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,7 @@ let yarg = yargs.usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $
   .alias('o', 'outDir').describe('o', 'Output directory')
   .alias('p', 'pattern').describe('p', 'Glob pattern with css files')
   .alias('w', 'watch').describe('w', 'Watch input directory\'s css files or pattern').boolean('w')
+  .alias('d', 'dropExtension').describe('d', 'Drop the input files extension').boolean('d')
   .alias('h', 'help').help('h')
   .version(() => require('../package.json').version)
 let argv = yarg.argv;
@@ -53,7 +54,13 @@ let main = () => {
   }
   let filesPattern = path.join(searchDir, argv.p || '**/*.css');
   rootDir = process.cwd();
-  creator = new DtsCreator({rootDir, searchDir, outDir: argv.o, camelCase: argv.c});
+  creator = new DtsCreator({
+    rootDir,
+    searchDir,
+    outDir: argv.o,
+    camelCase: argv.c,
+    dropExtension: argv.d
+  });
 
   if(!argv.w) {
     glob(filesPattern, null, (err, files) => {
@@ -74,4 +81,3 @@ let main = () => {
 };
 
 main();
-

--- a/src/dtsCreator.js
+++ b/src/dtsCreator.js
@@ -14,8 +14,14 @@ import os from 'os';
 
 let validator = new TokenValidator();
 
+function removeExtension(filePath) {
+  const ext = path.extname(filePath);
+  return filePath.replace(new RegExp(ext + '$'), '');
+}
+
 class DtsContent {
   constructor({
+    dropExtension,
     rootDir,
     searchDir,
     outDir,
@@ -24,6 +30,7 @@ class DtsContent {
     resultList,
     messageList
   }) {
+    this.dropExtension = dropExtension;
     this.rootDir = rootDir;
     this.searchDir = searchDir;
     this.outDir = outDir;
@@ -47,7 +54,8 @@ class DtsContent {
   }
 
   get outputFilePath() {
-    return path.join(this.rootDir, this.outDir, this.rInputPath + '.d.ts');
+    const outputFileName = this.dropExtension ? removeExtension(this.rInputPath) : this.rInputPath;
+    return path.join(this.rootDir, this.outDir, outputFileName + '.d.ts');
   }
 
   get inputFilePath() {
@@ -81,6 +89,7 @@ export class DtsCreator {
     this.inputDirectory = path.join(this.rootDir, this.searchDir);
     this.outputDirectory = path.join(this.rootDir, this.outDir);
     this.camelCase = !!options.camelCase;
+    this.dropExtension = !!options.dropExtension;
   }
 
   create(filePath, initialContents, clearCache = false) {
@@ -114,6 +123,7 @@ export class DtsCreator {
           var result = validKeys.map(k => ('export const ' + k + ': string;'));
 
           var content = new DtsContent({
+            dropExtension: this.dropExtension,
             rootDir: this.rootDir,
             searchDir: this.searchDir,
             outDir: this.outDir,

--- a/test/dtsCreator.spec.js
+++ b/test/dtsCreator.spec.js
@@ -77,6 +77,22 @@ describe('DtsContent', () => {
     });
   });
 
+  describe('#outputFilePath', () => {
+    it('adds d.ts to the original filename', done => {
+      new DtsCreator().create('test/testStyle.css').then(content => {
+        assert.equal(path.relative(process.cwd(), content.outputFilePath), "test/testStyle.css.d.ts");
+        done();
+      });
+    });
+
+    it('can drop the original extension when asked', done => {
+      new DtsCreator({dropExtension: true}).create('test/testStyle.css').then(content => {
+        assert.equal(path.relative(process.cwd(), content.outputFilePath), "test/testStyle.d.ts");
+        done();
+      });
+    });
+  });
+
   describe('#formatted', () => {
     it('returns formatted .d.ts string', done => {
       new DtsCreator().create('test/testStyle.css').then(content => {


### PR DESCRIPTION
Resolves: https://github.com/Quramy/typed-css-modules/issues/21

- Adds `yargs` argument `-d` / `dropExtension`
- Adds tests
- Trims the input file extension when flag is specified.