### PR TITLE
Add 'dashes' option for camelCase 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Creates TypeScript definition files from [CSS Modules](https://github.com/css-modules/css-modules) .css files.
 
-If you have the following css, 
+If you have the following css,
 
 ```css
 /* styles.css */
@@ -37,7 +37,7 @@ console.log(`<div style="color: ${styles.primary}"></div>`);
 npm install -g typed-css-modules
 ```
 
-And exec `tcm <input directory>` command. 
+And exec `tcm <input directory>` command.
 For example, if you have .css files under `src` directory, exec the following:
 
 ```sh
@@ -84,7 +84,24 @@ With `-w` or `--watch`, this CLI watches files in the input directory.
 
 #### camelize CSS token
 With `-c` or `--camelCase`, kebab-cased CSS classes(such as `.my-class {...}`) are exported as camelized TypeScript varibale name(`export const myClass: string`).
-See also [webpack css-loader's camelCase option](https://github.com/webpack/css-loader#camel-case).
+
+
+You can pass `--camelCase dashes` to only camelize dashes in the class name. Since version `0.27.1` in the
+webpack `css-loader`. This will keep upperCase class names intact, e.g.:
+
+```css
+.SomeComponent {
+  height: 10px;
+}
+```
+
+becomes
+
+```typescript
+export const SomeComponent: string;
+```
+
+See also [webpack css-loader's camelCase option](https://github.com/webpack/css-loader#camelcase).
 
 ## API
 
@@ -108,7 +125,7 @@ DtsCreator instance processes the input CSS and create TypeScript definition con
 #### `new DtsCreator(option)`
 You can set the following options:
 
-* `option.rootDir`: Project root directory(default: `process.cwd()`). 
+* `option.rootDir`: Project root directory(default: `process.cwd()`).
 * `option.searchDir`: Directory which includes target `*.css` files(default: `'./'`).
 * `option.outDir`: Output directory(default: `option.searchDir`).
 * `option.camelCase`: Camelize CSS class tokens.

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ let yarg = yargs.usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $
   .example('$0 -p styles/**/*.icss -w')
   .detectLocale(false)
   .demand(['_'])
-  .alias('c', 'camelCase').describe('c', 'Convert CSS class tokens to camelcase').boolean('c')
+  .alias('c', 'camelCase').describe('c', 'Convert CSS class tokens to camelcase')
   .alias('o', 'outDir').describe('o', 'Output directory')
   .alias('p', 'pattern').describe('p', 'Glob pattern with css files')
   .alias('w', 'watch').describe('w', 'Watch input directory\'s css files or pattern').boolean('w')

--- a/src/dtsCreator.js
+++ b/src/dtsCreator.js
@@ -88,7 +88,7 @@ export class DtsCreator {
     this.loader = new FileSystemLoader(this.rootDir);
     this.inputDirectory = path.join(this.rootDir, this.searchDir);
     this.outputDirectory = path.join(this.rootDir, this.outDir);
-    this.camelCase = !!options.camelCase;
+    this.camelCase = options.camelCase;
     this.dropExtension = !!options.dropExtension;
   }
 
@@ -110,8 +110,10 @@ export class DtsCreator {
           var validKeys = [], invalidKeys = [];
           var messageList = [];
 
+          var convertKey = this.getConvertKeyMethod(this.camelCase);
+
           keys.forEach(key => {
-            const convertedKey = this.camelCase ? camelcase(key) : key;
+            const convertedKey = convertKey(key);
             var ret = validator.validate(convertedKey);
             if(ret.isValid) {
               validKeys.push(convertedKey);
@@ -140,4 +142,29 @@ export class DtsCreator {
       }).catch(err => reject(err));
     });
   }
+
+  getConvertKeyMethod(camelCaseOption) {
+    switch (camelCaseOption) {
+      case true:
+        return camelcase;
+      case 'dashes':
+        return this.dashesCamelCase;
+      default:
+        return (key) => key;
+    }
+  }
+
+  /**
+   * Replaces only the dashes and leaves the rest as-is.
+   *
+   * Mirrors the behaviour of the css-loader:
+   * https://github.com/webpack-contrib/css-loader/blob/1fee60147b9dba9480c9385e0f4e581928ab9af9/lib/compile-exports.js#L3-L7
+   */
+  dashesCamelCase(str) {
+    return str.replace(/-+(\w)/g, function(match, firstLetter) {
+      return firstLetter.toUpperCase();
+    });
+  }
+
+
 }

--- a/test/dtsCreator.spec.js
+++ b/test/dtsCreator.spec.js
@@ -108,12 +108,29 @@ describe('DtsContent', () => {
       });
     });
 
-    it('returns camelized tokens when the camelCase option is set', done => {
-      new DtsCreator({camelCase: true}).create('test/kebabed.css').then(content => {
-        assert.equal(content.formatted, "export const myClass: string;");
-        done();
+    describe('#camelCase option', () => {
+      it('camelCase == true: returns camelized tokens for lowercase classes', done => {
+        new DtsCreator({camelCase: true}).create('test/kebabed.css').then(content => {
+          assert.equal(content.formatted, "export const myClass: string;");
+          done();
+        });
+      });
+
+      it('camelCase == true: returns camelized tokens for uppercase classes ', done => {
+        new DtsCreator({camelCase: true}).create('test/kebabedUpperCase.css').then(content => {
+          assert.equal(content.formatted, "export const myClass: string;");
+          done();
+        });
+      });
+
+      it('camelCase == "dashes": returns camelized tokens for dashes only', done => {
+        new DtsCreator({camelCase: 'dashes'}).create('test/kebabedUpperCase.css').then(content => {
+          assert.equal(content.formatted, "export const MyClass: string;");
+          done();
+        });
       });
     });
+
   });
 
   describe('#writeFile', () => {

--- a/test/kebabedUpperCase.css
+++ b/test/kebabedUpperCase.css
@@ -1,0 +1,3 @@
+.My-class {
+  color: red;
+}


### PR DESCRIPTION
The [css-loader camelCase](https://github.com/webpack-contrib/css-loader#camelcase) parameter takes a new option called `dashes`, which only camelizes dashes in the resulting module. This is handy if you have classes starting with an upper case.

## Example

```css
.My-class {
  color: red;
}
```

My `webpack.config` contains the following rule:

```js
{
  loader: 'css-loader',
  options: {
    // Enable CSS modules
    modules: true,
    // Export Classnames in CamelCase
    camelCase: 'dashesOnly',
  }
}
```

Which creates a css module object like this

```js
{
  MyClass: '....'
}
```

With this pull request, we can configure the typed-css-module loader the same way:

```
{
  enforce: 'pre',
  test: /\.css$/,
  exclude: /node_modules/,
  loader: 'typed-css-modules-loader',
  options: {
   camelCase: 'dashesOnly'
  }
}
```