### PR TITLE
Adding the possibility of inserting an arbitrary EOF

### DIFF
--- a/src/dtsCreator.js
+++ b/src/dtsCreator.js
@@ -28,7 +28,8 @@ class DtsContent {
     rInputPath,
     rawTokenList,
     resultList,
-    messageList
+    messageList,
+    EOL
   }) {
     this.dropExtension = dropExtension;
     this.rootDir = rootDir;
@@ -38,6 +39,7 @@ class DtsContent {
     this.rawTokenList = rawTokenList;
     this.resultList = resultList;
     this.messageList = messageList;
+    this.EOL = EOL;
   }
 
   get contents() {
@@ -46,7 +48,7 @@ class DtsContent {
 
   get formatted() {
     if(!this.resultList || !this.resultList.length) return '';
-    return this.resultList.join(os.EOL);
+    return this.resultList.join(this.EOL);
   }
 
   get tokens() {
@@ -68,7 +70,7 @@ class DtsContent {
       mkdirp.sync(outPathDir);
     }
     return new Promise((resolve, reject) => {
-      fs.writeFile(this.outputFilePath, this.formatted + os.EOL, 'utf8', (err) => {
+      fs.writeFile(this.outputFilePath, this.formatted + this.EOL, 'utf8', (err) => {
         if(err) {
           reject(err);
         }else{
@@ -90,6 +92,7 @@ export class DtsCreator {
     this.outputDirectory = path.join(this.rootDir, this.outDir);
     this.camelCase = options.camelCase;
     this.dropExtension = !!options.dropExtension;
+    this.EOL = options.EOL || os.EOL;
   }
 
   create(filePath, initialContents, clearCache = false) {
@@ -132,7 +135,8 @@ export class DtsCreator {
             rInputPath,
             rawTokenList: keys,
             resultList: result,
-            messageList
+            messageList,
+            EOL: this.EOL
           });
 
           resolve(content);


### PR DESCRIPTION
@Quramy @olegstepura first of all, thank you for your great work!

In our project we use git with different operating systems, and for the convenience of development we decided to store our files with `LF` ending. We use `typed-css-modules-loader` which passes the parameters to the `typed-css-modules` via options:
```
{
  loader: 'typed-css-modules-loader',
    options: {
        // params for typed-css-modules
    },
},
```

the problem is that when the programmer  that uses `Mac os` generates a change, then the `d.ts` file is saved in the `LF` format, and if the programmer that uses `Windows` does this, the `d.ts` file is saved in the `CRLF` format. Because of this we see many changed files in which there are actually no changes:

![screenshot_11](https://user-images.githubusercontent.com/1275228/39272446-97298d36-48e4-11e8-8482-3986ab74498f.png)

all changes are just EOL:

![screenshot_12](https://user-images.githubusercontent.com/1275228/39272471-ab6d10e2-48e4-11e8-9a5d-d028e99a6b8b.png)

we needed to directly specify the type of `EOL` that we need, but unfortunately this option was not available and we had to create a fork. Perhaps this option will be useful to other users, so I created a pr.

usage with `typed-css-modules-loader`:
```
{
  loader: 'typed-css-modules-loader',
    options: {
      EOL: '\r\n', // or '\n'
   },
},
```

If there are no options, then by default, there will be an old behavior with an `os.EOL`