### PR TITLE
Avoid EOL for blank file

### DIFF
--- a/src/dtsCreator.js
+++ b/src/dtsCreator.js
@@ -47,8 +47,8 @@ class DtsContent {
   }
 
   get formatted() {
-    if(!this.resultList || !this.resultList.length) return '';
-    return this.resultList.join(this.EOL);
+    if(!this.resultList || !this.resultList.length || this.resultList.length === 0) return '';
+    return this.resultList.join(this.EOL) + this.EOL;
   }
 
   get tokens() {
@@ -70,7 +70,7 @@ class DtsContent {
       mkdirp.sync(outPathDir);
     }
     return new Promise((resolve, reject) => {
-      fs.writeFile(this.outputFilePath, this.formatted + this.EOL, 'utf8', (err) => {
+      fs.writeFile(this.outputFilePath, this.formatted, 'utf8', (err) => {
         if(err) {
           reject(err);
         }else{

--- a/test/dtsCreator.spec.js
+++ b/test/dtsCreator.spec.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var assert = require('assert');
 var DtsCreator = require('../lib/dtsCreator').DtsCreator;
+var os = require('os');
 
 describe('DtsCreator', () => {
   var creator = new DtsCreator();
@@ -96,7 +97,7 @@ describe('DtsContent', () => {
   describe('#formatted', () => {
     it('returns formatted .d.ts string', done => {
       new DtsCreator().create('test/testStyle.css').then(content => {
-        assert.equal(content.formatted, "export const myClass: string;");
+        assert.equal(content.formatted, "export const myClass: string;" + os.EOL);
         done();
       });
     });
@@ -111,21 +112,21 @@ describe('DtsContent', () => {
     describe('#camelCase option', () => {
       it('camelCase == true: returns camelized tokens for lowercase classes', done => {
         new DtsCreator({camelCase: true}).create('test/kebabed.css').then(content => {
-          assert.equal(content.formatted, "export const myClass: string;");
+          assert.equal(content.formatted, "export const myClass: string;" + os.EOL);
           done();
         });
       });
 
       it('camelCase == true: returns camelized tokens for uppercase classes ', done => {
         new DtsCreator({camelCase: true}).create('test/kebabedUpperCase.css').then(content => {
-          assert.equal(content.formatted, "export const myClass: string;");
+          assert.equal(content.formatted, "export const myClass: string;" + os.EOL);
           done();
         });
       });
 
       it('camelCase == "dashes": returns camelized tokens for dashes only', done => {
         new DtsCreator({camelCase: 'dashes'}).create('test/kebabedUpperCase.css').then(content => {
-          assert.equal(content.formatted, "export const MyClass: string;");
+          assert.equal(content.formatted, "export const MyClass: string;" + os.EOL);
           done();
         });
       });


### PR DESCRIPTION
Currently, `createFile` creates an empty file with EOL for an empty css file.

In my project, we use prettier and it removes EOL for empty files.

AFAIK, an empty file doesn't have to have EOL.

> A source file that is not empty shall end in a new-line character

http://gcc.gnu.org/ml/gcc/2003-11/msg01568.html

https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline