### PR TITLE
allow for all names of tokens to be emitted

### DIFF
--- a/src/tokenValidator.js
+++ b/src/tokenValidator.js
@@ -6,24 +6,28 @@ export class TokenValidator {
   validate(key) {
     if(!key) {
       return {
-        isValid: false,
+        isValidVariableName: false,
+        isValidObjectKeyName: false,
         message: 'empty token'
       };
     }
     if(!/^[$_a-zA-ZÀ-ÿ][0-9a-zA-ZÀ-ÿ$_]*$/.test(key)) {
       return {
-        isValid: false,
+        isValidVariableName: false,
+        isValidObjectKeyName: true,
         message: key + ' is not valid TypeScript variable name.'
       };
     }
     if(RESERVED_WORDS.some(w => w === key)) {
       return {
-        isValid: false,
+        isValidVariableName: false,
+        isValidObjectKeyName: true,
         message: key + ' is TypeScript reserved word.'
       };
     }
     return {
-      isValid: true
+      isValidVariableName: true,
+      isValidObjectKeyName: true,
     };
   }
 }


### PR DESCRIPTION
hey @Quramy,

in this PR you will find a different emit style for type definitions, that would allow for all currently invalid tokens to be defined as well. 

the emitted definition for the example would become:
```
interface Styles {
  primary: string;
  root: string;
  some_id: string;
  main: string;
  'my-class1': string;
  'myclass-2': string;
}

declare const _: Styles;
export = _;
```

which for currently valid tokens would be no change, yet invalid ones could also be consumed via index access like `styles['myclass-2']`

```
import * as styles from './style01.css';

console.log(`<div class="${styles.root + ' ' + styles["my-class1"]}" style="color: ${styles.primary}"></div>`);
```

what do you think about this change. i could also make it optional, though the question would be if this is needed, as the new definition should be fully backward compatible.