### PR TITLE
Remove unecessary TypeError on build

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -30,9 +30,11 @@ function writeFile(f) {
   .then(content => {
     if (!argv.s) {
       console.log('Wrote ' + chalk.green(content.outputFilePath));
-      content.messageList.forEach(message => {
-        console.warn(chalk.yellow('[Warn] ' + message));
-      });
+      if (content.messageList && content.messageList.length) {
+        content.messageList.forEach(message => {
+          console.warn(chalk.yellow('[Warn] ' + message));
+        });
+      }
     }
   })
   .catch(reason => console.error(chalk.red('[Error] ' + reason)));


### PR DESCRIPTION
The following error occurs when running tcm:

[Error] TypeError: Cannot read property 'forEach' of undefined

After some debugging, it became clear that this is caused by a missing if statement checking if the messageList exists or not.

If the error is there due to some reason unknown to me, please elaborate :)