### PR TITLE
Add loaderPlugin option

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
+    "@types/css-modules-loader-core": "^1.1.0",
     "camelcase": "^5.3.1",
     "chalk": "^2.1.0",
     "chokidar": "^2.1.2",
@@ -38,7 +39,6 @@
     "yargs": "^8.0.2"
   },
   "devDependencies": {
-    "@types/css-modules-loader-core": "^1.1.0",
     "@types/glob": "^7.1.1",
     "@types/mkdirp": "^0.5.1",
     "@types/node": "^12.0.3",

--- a/src/DtsCreator.ts
+++ b/src/DtsCreator.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import camelcase from "camelcase"
 import FileSystemLoader from './FileSystemLoader';
 import {DtsContent} from "./DtsContent";
+import {Plugin} from "postcss";
 
 
 type CamelCaseOption = boolean | 'dashes' | undefined;
@@ -15,6 +16,7 @@ interface DtsCreatorOptions {
   camelCase?: CamelCaseOption;
   dropExtension?: boolean;
   EOL?: string;
+  loaderPlugins?: Plugin<any>[];
 }
 
 export class DtsCreator {
@@ -33,7 +35,7 @@ export class DtsCreator {
     this.rootDir = options.rootDir || process.cwd();
     this.searchDir = options.searchDir || '';
     this.outDir = options.outDir || this.searchDir;
-    this.loader = new FileSystemLoader(this.rootDir);
+    this.loader = new FileSystemLoader(this.rootDir, options.loaderPlugins);
     this.inputDirectory = path.join(this.rootDir, this.searchDir);
     this.outputDirectory = path.join(this.rootDir, this.outDir);
     this.camelCase = options.camelCase;


### PR DESCRIPTION
hi @Quramy,

this time a very small one. adding a `loaderPlugins` to the `DtsCreator` API would help consumers like the following to not need to "hack" access private fields.

https://github.com/dropbox/typed-css-modules-webpack-plugin/blob/ce78deebe24ece72a69ca94984cddf98b9cebddf/src/index.ts#L38

this would also help to surface future problems in consumers, as they would rely on the typings.

what do you think?