### PR TITLE
Provide "run" API

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,10 @@
-src/
-gulpfile.js
+# ignore everything
+*
+
+# include these:
+!/lib/**/*
+!LICENSE.md
+!README.md
+
+# exclude hidden files from the includes:
+.*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc && chmod +x lib/cli.js",
+    "clean": "rm -rf lib/",
+    "build": "yarn clean && tsc && chmod +x lib/cli.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --coverage",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,11 +2,14 @@
 
 import * as path from 'path';
 import * as chokidar from 'chokidar';
-import glob from 'glob';
+import _glob from 'glob';
 import * as yargs from 'yargs';
 import chalk from 'chalk';
 import {DtsCreator} from './dts-creator';
 import {DtsContent} from "./dts-content";
+import * as util from "util";
+
+const glob = util.promisify(_glob);
 
 const yarg = yargs.usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $0 [options] <input directory>')
   .example('$0 src/styles', '')
@@ -39,7 +42,7 @@ async function writeFile(f: string): Promise<void> {
   }
 };
 
-function main() {
+async function main() {
   let rootDir: string;
   let searchDir: string;
   if(argv.h) {
@@ -66,14 +69,8 @@ function main() {
   });
 
   if(!argv.w) {
-    glob(filesPattern, {}, (err, files) => {
-      if(err) {
-        console.error(err);
-        return;
-      }
-      if(!files || !files.length) return;
-      files.forEach(writeFile);
-    });
+    const files = await glob(filesPattern);
+    files.forEach(writeFile);
   } else {
     console.log('Watch ' + filesPattern + '...');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-import { DtsCreator } from './dts-creator';
-export = DtsCreator;
+export {DtsCreator as default} from './dts-creator';
+export {run} from './run';

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,61 @@
+import * as path from "path";
+import * as util from "util";
+import chalk from "chalk";
+import * as chokidar from "chokidar";
+import _glob from 'glob';
+import {DtsCreator} from "./dts-creator";
+import {DtsContent} from "./dts-content";
+
+const glob = util.promisify(_glob);
+
+
+interface RunOptions {
+    pattern?: string;
+    outDir?: string;
+    watch?: boolean;
+    camelCase?: boolean;
+    dropExtension?: boolean;
+    silent?: boolean;
+}
+
+export async function run(searchDir: string, options: RunOptions = {}): Promise<void> {
+    const filesPattern = path.join(searchDir, options.pattern || '**/*.css');
+
+    const creator = new DtsCreator({
+        rootDir: process.cwd(),
+        searchDir,
+        outDir: options.outDir,
+        camelCase: options.camelCase,
+        dropExtension: options.dropExtension,
+    });
+
+    const writeFile = async (f: string): Promise<void> => {
+        try {
+            const content: DtsContent = await creator.create(f, undefined, !!options.watch);
+            await content.writeFile();
+
+            if (!options.silent) {
+                console.log('Wrote ' + chalk.green(content.outputFilePath));
+            }
+        }
+        catch (error) {
+            console.error(chalk.red('[Error] ' + error));
+        }
+    };
+
+    if(!options.watch) {
+        const files = await glob(filesPattern);
+        await Promise.all(files.map(writeFile));
+    } else {
+        console.log('Watch ' + filesPattern + '...');
+
+        const watcher = chokidar.watch([filesPattern.replace(/\\/g, "/")]);
+        watcher.on('add', writeFile);
+        watcher.on('change', writeFile);
+        await waitForever();
+    }
+}
+
+async function waitForever(): Promise<void> {
+    return new Promise<void>(() => {});
+}


### PR DESCRIPTION
This PR adds a run API, which allows to use not only the cli, but also an API to create definitions. 

I also changed `export = DtsCreator;` to a default export in `index.js`. This solves an issues where consumers had to use `esModuleInterop`. `export =` is the old syntax. The export might break API compability. I would therefore increase the version to `0.6.0`.

The changes of this PR are all in one commit ("
export cli functionality via API"). yet they are based on the changes of the other to PR's i opened.