### PR TITLE
Allow file postprocessors like Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,18 @@ Returns `DtsContent` instance.
 ### class DtsContent
 DtsContent instance has `*.d.ts` content, final output path, and function to write file.
 
-#### `writeFile() => Promise(dtsContent)`
-Writes the DtsContent instance's content to a file.
+#### `writeFile(postprocessor) => Promise(dtsContent)`
+Writes the DtsContent instance's content to a file. Returns the DtsContent instance.
 
-* `dtsContent`: the DtsContent instance itself.
+* `postprocessor` (optional): a function that takes the formatted definition string and returns a modified string that will be the final content written to the file.
+
+  You could use this, for example, to pass generated definitions through a formatter like Prettier, or to add a comment to the top of generated files:
+
+  ```js
+  dtsContent.writeFile(
+    definition => `// Generated automatically, do not edit\n${definition}`
+  )
+  ```
 
 #### `tokens`
 An array of tokens retrieved from input CSS file.

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -68,13 +68,15 @@ export class DtsContent {
         return path.join(this.rootDir, this.searchDir, this.rInputPath);
     }
 
-    public async writeFile(): Promise<void> {
+    public async writeFile(postprocessor = (formatted: string) => formatted): Promise<void> {
+        const finalOutput = postprocessor(this.formatted);
+
         const outPathDir = path.dirname(this.outputFilePath);
         if(!isThere(outPathDir)) {
             mkdirp.sync(outPathDir);
         }
 
-        await writeFile(this.outputFilePath, this.formatted, 'utf8');
+        await writeFile(this.outputFilePath, finalOutput, 'utf8');
     }
 }
 

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -180,6 +180,19 @@ export = styles;
   });
 
   describe('#writeFile', () => {
+    it('accepts a postprocessor function', done => {
+      new DtsCreator()
+        .create('test/testStyle.css')
+        .then(content => {
+          return content.writeFile(
+            formatted => `// this banner was added to the .d.ts file automatically.\n${formatted}`
+          );
+        })
+        .then(() => {
+          done();
+        });
+    });
+
     it('writes a file', done => {
       new DtsCreator()
         .create('test/testStyle.css')


### PR DESCRIPTION
Thanks for this module! One important feature that's missing to me is the ability to easily format generated files with some kind of postprocessor (eg. Prettier). For example, in the project I'm working on now, unformatted files will fail the build on CI.

This PR adds a simple parameter to `DtsCreator#writeFile` to allow it to accept a postprocessor function, a function that accepts the formatted output from the creator and then returns a string with whatever postprocessing applied. It defaults to the identity function, making it optional. A test was also added.

Postprocessing is also useful for anyone who wants to add a banner comment to the top of their generated files, eg. `// This file was generated automatically. Do not edit by hand!`