### PR TITLE
feat: add singleQuote option to allow custom style for keys with dashes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,189 @@
+## GITATTRIBUTES FOR WEB PROJECTS
+#
+# These settings are for any web project.
+#
+# Details per file setting:
+#   text    These files should be normalized (i.e. convert CRLF to LF).
+#   binary  These files are binary and should be left untouched.
+#
+# Note that binary is a macro for -text -diff.
+# Source: https://github.com/Danimoth/gitattributes/blob/master/Web.gitattributes
+######################################################################
+
+## AUTO-DETECT - Handle line endings automatically for files detected
+## as text and leave all files detected as binary untouched.
+## This will handle all files NOT defined below.
+* text=auto
+
+## SOURCE CODE
+*.bat    text eol=lf
+*.coffee text eol=lf
+*.css    text eol=lf
+*.frag   text eol=lf
+*.htm    text eol=lf
+*.html   text eol=lf
+*.inc    text eol=lf
+*.ini    text eol=lf
+*.js     text eol=lf
+*.jsx    text eol=lf
+*.json   text eol=lf
+*.gql    text eol=lf
+*.kml    text eol=lf
+*.less   text eol=lf
+*.php    text eol=lf
+*.pl     text eol=lf
+*.py     text eol=lf
+*.rb     text eol=lf
+*.sass   text eol=lf
+*.scm    text eol=lf
+*.scss   text eol=lf
+*.sh     text eol=lf
+*.sql    text eol=lf
+*.styl   text eol=lf
+*.ts     text eol=lf
+*.vue    text eol=lf
+*.xml    text eol=lf
+*.xhtml  text eol=lf
+*.xsl    text eol=lf
+
+## DOCUMENTATION
+*.markdown   text eol=lf
+*.md         text eol=lf
+*.mdwn       text eol=lf
+*.mdown      text eol=lf
+*.mkd        text eol=lf
+*.mkdn       text eol=lf
+*.mdtxt      text eol=lf
+*.mdtext     text eol=lf
+*.txt        text eol=lf
+AUTHORS      text eol=lf
+CHANGELOG    text eol=lf
+CHANGES      text eol=lf
+CONTRIBUTING text eol=lf
+COPYING      text eol=lf
+INSTALL      text eol=lf
+license      text eol=lf
+LICENSE      text eol=lf
+NEWS         text eol=lf
+readme       text eol=lf
+*README*     text eol=lf
+TODO         text eol=lf
+
+## TEMPLATES
+*.dot        text eol=lf
+*.ejs        text eol=lf
+*.haml       text eol=lf
+*.handlebars text eol=lf
+*.hbs        text eol=lf
+*.hbt        text eol=lf
+*.jade       text eol=lf
+*.latte      text eol=lf
+*.mustache   text eol=lf
+*.phtml      text eol=lf
+*.tmpl       text eol=lf
+
+## LINTERS
+.csslintrc    text eol=lf
+.eslintrc     text eol=lf
+.jscsrc       text eol=lf
+.jshintrc     text eol=lf
+.jshintignore text eol=lf
+.stylelintrc  text eol=lf
+
+## CONFIGS
+.babelrc       text eol=lf
+.npmrc         text eol=lf
+.yarnrc        text eol=lf
+*.bowerrc      text eol=lf
+*.cnf          text eol=lf
+*.conf         text eol=lf
+*.config       text eol=lf
+.editorconfig  text eol=lf
+.env*          text eol=lf
+.flowconfig    text eol=lf
+.eslintignore  text eol=lf
+.gitattributes text eol=lf
+.gitconfig     text eol=lf
+.gitignore     text eol=lf
+.htaccess      text eol=lf
+.jsbeautifyrc  text eol=lf
+*.npmignore    text eol=lf
+*.yaml         text eol=lf
+*.yml          text eol=lf
+*.js.flow      text eol=lf
+*.lock         text eol=lf
+Makefile       text eol=lf
+makefile       text eol=lf
+
+## HEROKU
+Procfile       text eol=lf
+.slugignore    text eol=lf
+
+## GRAPHICS
+*.ai   binary
+*.bmp  binary
+*.eps  binary
+*.gif  binary
+*.ico  binary
+*.jng  binary
+*.jp2  binary
+*.jpg  binary
+*.jpeg binary
+*.jpx  binary
+*.jxr  binary
+*.pdf  binary
+*.png  binary
+*.psb  binary
+*.psd  binary
+*.svg  text eol=lf
+*.svgz binary
+*.tif  binary
+*.tiff binary
+*.wbmp binary
+*.webp binary
+
+## AUDIO
+*.kar  binary
+*.m4a  binary
+*.mid  binary
+*.midi binary
+*.mp3  binary
+*.ogg  binary
+*.ra   binary
+
+## VIDEO
+*.3gpp binary
+*.3gp  binary
+*.as   binary
+*.asf  binary
+*.asx  binary
+*.fla  binary
+*.flv  binary
+*.m4v  binary
+*.mng  binary
+*.mov  binary
+*.mp4  binary
+*.mpeg binary
+*.mpg  binary
+*.swc  binary
+*.swf  binary
+*.webm binary
+
+## ARCHIVES
+*.7z  binary
+*.gz  binary
+*.rar binary
+*.tar binary
+*.zip binary
+
+## FONTS
+*.ttf   binary
+*.eot   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+
+## EXECUTABLES
+*.exe binary
+*.pyc binary
+*.mwb binary

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ export const SomeComponent: string;
 
 See also [webpack css-loader's camelCase option](https://github.com/webpack/css-loader#camelcase).
 
+#### Use single quotes to class names in the .d.ts files
+
+With `-sq` or `--singleQuote`, you can configure what quote to use. Useful when tools like prettier format your .d.ts files.
+
 ## API
 
 ```sh
@@ -132,6 +136,7 @@ You can set the following options:
 * `option.searchDir`: Directory which includes target `*.css` files(default: `'./'`).
 * `option.outDir`: Output directory(default: `option.searchDir`).
 * `option.camelCase`: Camelize CSS class tokens.
+* `option.singleQuote`: Use single quotes on dashed keys.
 * `option.EOL`: EOL (end of line) for the generated `d.ts` files. Possible values `'\n'` or `'\r\n'`(default: `os.EOL`).
 
 #### `create(filepath, contents) => Promise(dtsContent)`

--- a/example/style01.css
+++ b/example/style01.css
@@ -12,4 +12,3 @@
 #some_id.main > div.my-class1.myclass-2 {
   width: 100px;
 }
-

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,41 +1,57 @@
 #!/usr/bin/env node
 
 import * as yargs from 'yargs';
-import {run} from "./run";
+import { run } from './run';
 
-
-const yarg = yargs.usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $0 [options] <search directory>')
+const yarg = yargs
+  .usage(
+    'Create .css.d.ts from CSS modules *.css files.\nUsage: $0 [options] <search directory>'
+  )
   .example('$0 src/styles', '')
   .example('$0 src -o dist', '')
   .example('$0 -p styles/**/*.icss -w', '')
   .detectLocale(false)
   .demand(['_'])
-  .alias('p', 'pattern').describe('p', 'Glob pattern with css files')
-  .alias('o', 'outDir').describe('o', 'Output directory')
-  .alias('w', 'watch').describe('w', 'Watch input directory\'s css files or pattern').boolean('w')
-  .alias('c', 'camelCase').describe('c', 'Convert CSS class tokens to camelcase')
-  .alias('d', 'dropExtension').describe('d', 'Drop the input files extension').boolean('d')
-  .alias('s', 'silent').describe('s', 'Silent output. Do not show "files written" messages').boolean('s')
-  .alias('h', 'help').help('h')
+  .alias('p', 'pattern')
+  .describe('p', 'Glob pattern with css files')
+  .alias('o', 'outDir')
+  .describe('o', 'Output directory')
+  .alias('w', 'watch')
+  .describe('w', "Watch input directory's css files or pattern")
+  .boolean('w')
+  .alias('c', 'camelCase')
+  .describe('c', 'Convert CSS class tokens to camelcase')
+  .alias('sq', 'singleQuote')
+  .describe(
+    'sq',
+    'Use single quotes for writing the keys when they have a dash'
+  )
+  .alias('d', 'dropExtension')
+  .describe('d', 'Drop the input files extension')
+  .boolean('d')
+  .alias('s', 'silent')
+  .describe('s', 'Silent output. Do not show "files written" messages')
+  .boolean('s')
+  .alias('h', 'help')
+  .help('h')
   .version(require('../package.json').version);
-
 
 main();
 
 async function main(): Promise<void> {
   const argv = yarg.argv;
 
-  if(argv.h) {
+  if (argv.h) {
     yarg.showHelp();
     return;
   }
 
   let searchDir: string;
-  if(argv._ && argv._[0]) {
+  if (argv._ && argv._[0]) {
     searchDir = argv._[0];
-  }else if(argv.p) {
+  } else if (argv.p) {
     searchDir = './';
-  }else{
+  } else {
     yarg.showHelp();
     return;
   }
@@ -45,7 +61,8 @@ async function main(): Promise<void> {
     outDir: argv.o,
     watch: argv.w,
     camelCase: argv.c,
+    singleQuote: argv.sq,
     dropExtension: argv.d,
     silent: argv.s
   });
-};
+}

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -1,86 +1,95 @@
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
-import isThere from "is-there";
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import isThere from 'is-there';
 import * as mkdirp from 'mkdirp';
-import * as util from "util";
+import * as util from 'util';
 
 const writeFile = util.promisify(fs.writeFile);
 
-
 interface DtsContentOptions {
-    dropExtension: boolean;
-    rootDir: string;
-    searchDir: string;
-    outDir: string;
-    rInputPath: string;
-    rawTokenList: string[];
-    resultList: string[];
-    EOL: string;
+  dropExtension: boolean;
+  rootDir: string;
+  searchDir: string;
+  outDir: string;
+  rInputPath: string;
+  rawTokenList: string[];
+  resultList: string[];
+  EOL: string;
+  singleQuote?: boolean;
 }
 
 export class DtsContent {
-    private dropExtension: boolean;
-    private rootDir: string;
-    private searchDir: string;
-    private outDir: string;
-    private rInputPath: string;
-    private rawTokenList: string[];
-    private resultList: string[];
-    private EOL: string;
+  private dropExtension: boolean;
+  private rootDir: string;
+  private searchDir: string;
+  private outDir: string;
+  private singleQuote?: boolean;
+  private rInputPath: string;
+  private rawTokenList: string[];
+  private resultList: string[];
+  private EOL: string;
 
-    constructor(options: DtsContentOptions) {
-        this.dropExtension = options.dropExtension;
-        this.rootDir = options.rootDir;
-        this.searchDir = options.searchDir;
-        this.outDir = options.outDir;
-        this.rInputPath = options.rInputPath;
-        this.rawTokenList = options.rawTokenList;
-        this.resultList = options.resultList;
-        this.EOL = options.EOL;
+  constructor(options: DtsContentOptions) {
+    this.dropExtension = options.dropExtension;
+    this.rootDir = options.rootDir;
+    this.searchDir = options.searchDir;
+    this.outDir = options.outDir;
+    this.singleQuote = options.singleQuote;
+    this.rInputPath = options.rInputPath;
+    this.rawTokenList = options.rawTokenList;
+    this.resultList = options.resultList;
+    this.EOL = options.EOL;
+  }
+
+  public get contents(): string[] {
+    return this.resultList;
+  }
+
+  public get formatted(): string {
+    if (!this.resultList || !this.resultList.length) return '';
+
+    const data = [
+      'declare const styles: {',
+      ...this.resultList.map(line => '  ' + line),
+      '};',
+      'export = styles;',
+      ''
+    ].join(this.EOL);
+
+    return this.singleQuote ? data.replace(/\"/g, "'") : data;
+  }
+
+  public get tokens(): string[] {
+    return this.rawTokenList;
+  }
+
+  public get outputFilePath(): string {
+    const outputFileName = this.dropExtension
+      ? removeExtension(this.rInputPath)
+      : this.rInputPath;
+    return path.join(this.rootDir, this.outDir, outputFileName + '.d.ts');
+  }
+
+  public get inputFilePath(): string {
+    return path.join(this.rootDir, this.searchDir, this.rInputPath);
+  }
+
+  public async writeFile(
+    postprocessor = (formatted: string) => formatted
+  ): Promise<void> {
+    const finalOutput = postprocessor(this.formatted);
+
+    const outPathDir = path.dirname(this.outputFilePath);
+    if (!isThere(outPathDir)) {
+      mkdirp.sync(outPathDir);
     }
 
-    public get contents(): string[] {
-        return this.resultList;
-    }
-
-    public get formatted(): string {
-        if(!this.resultList || !this.resultList.length) return '';
-        return [
-            'declare const styles: {',
-            ...this.resultList.map(line => '  ' + line),
-            '};',
-            'export = styles;',
-            ''
-        ].join(os.EOL) + this.EOL;
-    }
-
-    public get tokens(): string[] {
-        return this.rawTokenList;
-    }
-
-    public get outputFilePath(): string {
-        const outputFileName = this.dropExtension ? removeExtension(this.rInputPath) : this.rInputPath;
-        return path.join(this.rootDir, this.outDir, outputFileName + '.d.ts');
-    }
-
-    public get inputFilePath(): string {
-        return path.join(this.rootDir, this.searchDir, this.rInputPath);
-    }
-
-    public async writeFile(postprocessor = (formatted: string) => formatted): Promise<void> {
-        const finalOutput = postprocessor(this.formatted);
-
-        const outPathDir = path.dirname(this.outputFilePath);
-        if(!isThere(outPathDir)) {
-            mkdirp.sync(outPathDir);
-        }
-
-        await writeFile(this.outputFilePath, finalOutput, 'utf8');
-    }
+    await writeFile(this.outputFilePath, finalOutput, 'utf8');
+  }
 }
 
 function removeExtension(filePath: string): string {
-    const ext = path.extname(filePath);
-    return filePath.replace(new RegExp(ext + '$'), '');
+  const ext = path.extname(filePath);
+  return filePath.replace(new RegExp(ext + '$'), '');
 }

--- a/src/file-system-loader.ts
+++ b/src/file-system-loader.ts
@@ -1,18 +1,16 @@
 /* this file is forked from https://raw.githubusercontent.com/css-modules/css-modules-loader-core/master/src/file-system-loader.js */
 
-import Core from 'css-modules-loader-core'
-import * as fs from 'fs'
-import * as path from 'path'
-import * as util from 'util'
-import { Plugin } from "postcss";
-
+import Core from 'css-modules-loader-core';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as util from 'util';
+import { Plugin } from 'postcss';
 
 type Dictionary<T> = {
   [key: string]: T | undefined;
 };
 
 const readFile = util.promisify(fs.readFile);
-
 
 export default class FileSystemLoader {
   private root: string;
@@ -21,7 +19,7 @@ export default class FileSystemLoader {
   private core: Core;
   public tokensByFile: Dictionary<Core.ExportTokens>;
 
-  constructor( root: string, plugins?: Array<Plugin<any>> ) {
+  constructor(root: string, plugins?: Array<Plugin<any>>) {
     this.root = root;
     this.sources = {};
     this.importNr = 0;
@@ -29,34 +27,40 @@ export default class FileSystemLoader {
     this.tokensByFile = {};
   }
 
-  public async fetch(_newPath: string, relativeTo: string, _trace?: string, initialContents?: string): Promise<Core.ExportTokens> {
-    const newPath = _newPath.replace(/^["']|["']$/g, "");
+  public async fetch(
+    _newPath: string,
+    relativeTo: string,
+    _trace?: string,
+    initialContents?: string
+  ): Promise<Core.ExportTokens> {
+    const newPath = _newPath.replace(/^["']|["']$/g, '');
     const trace = _trace || String.fromCharCode(this.importNr++);
 
     const relativeDir = path.dirname(relativeTo);
     const rootRelativePath = path.resolve(relativeDir, newPath);
-    let fileRelativePath = path.resolve(path.join(this.root, relativeDir), newPath);
+    let fileRelativePath = path.resolve(
+      path.join(this.root, relativeDir),
+      newPath
+    );
 
     // if the path is not relative or absolute, try to resolve it in node_modules
     if (newPath[0] !== '.' && newPath[0] !== '/') {
       try {
         fileRelativePath = require.resolve(newPath);
-      }
-      catch (e) {}
+      } catch (e) {}
     }
 
     let source: string;
 
     if (!initialContents) {
-      const tokens = this.tokensByFile[fileRelativePath]
+      const tokens = this.tokensByFile[fileRelativePath];
       if (tokens) {
         return tokens;
       }
 
       try {
-        source = await readFile(fileRelativePath, "utf-8");
-      }
-      catch (error) {
+        source = await readFile(fileRelativePath, 'utf-8');
+      } catch (error) {
         if (relativeTo && relativeTo !== '/') {
           return {};
         }
@@ -67,7 +71,12 @@ export default class FileSystemLoader {
       source = initialContents;
     }
 
-    const { injectableSource, exportTokens } = await this.core.load(source, rootRelativePath, trace, this.fetch.bind(this));
+    const { injectableSource, exportTokens } = await this.core.load(
+      source,
+      rootRelativePath,
+      trace,
+      this.fetch.bind(this)
+    );
     this.sources[trace] = injectableSource;
     this.tokensByFile[fileRelativePath] = exportTokens;
     return exportTokens;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export {DtsCreator as default} from './dts-creator';
-export {run} from './run';
+export { DtsCreator as default } from './dts-creator';
+export { run } from './run';

--- a/src/is-there.d.ts
+++ b/src/is-there.d.ts
@@ -1,4 +1,4 @@
 declare module 'is-there' {
-    function isThere(path: string): boolean;
-    export = isThere;
+  function isThere(path: string): boolean;
+  export = isThere;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,61 +1,68 @@
-import * as path from "path";
-import * as util from "util";
-import chalk from "chalk";
-import * as chokidar from "chokidar";
+import * as path from 'path';
+import * as util from 'util';
+import chalk from 'chalk';
+import * as chokidar from 'chokidar';
 import _glob from 'glob';
-import {DtsCreator} from "./dts-creator";
-import {DtsContent} from "./dts-content";
+import { DtsCreator } from './dts-creator';
+import { DtsContent } from './dts-content';
 
 const glob = util.promisify(_glob);
 
-
 interface RunOptions {
-    pattern?: string;
-    outDir?: string;
-    watch?: boolean;
-    camelCase?: boolean;
-    dropExtension?: boolean;
-    silent?: boolean;
+  pattern?: string;
+  outDir?: string;
+  watch?: boolean;
+  camelCase?: boolean;
+  singleQuote?: boolean;
+  dropExtension?: boolean;
+  silent?: boolean;
 }
 
-export async function run(searchDir: string, options: RunOptions = {}): Promise<void> {
-    const filesPattern = path.join(searchDir, options.pattern || '**/*.css');
+export async function run(
+  searchDir: string,
+  options: RunOptions = {}
+): Promise<void> {
+  const filesPattern = path.join(searchDir, options.pattern || '**/*.css');
 
-    const creator = new DtsCreator({
-        rootDir: process.cwd(),
-        searchDir,
-        outDir: options.outDir,
-        camelCase: options.camelCase,
-        dropExtension: options.dropExtension,
-    });
+  const creator = new DtsCreator({
+    rootDir: process.cwd(),
+    searchDir,
+    outDir: options.outDir,
+    camelCase: options.camelCase,
+    singleQuote: options.singleQuote,
+    dropExtension: options.dropExtension
+  });
 
-    const writeFile = async (f: string): Promise<void> => {
-        try {
-            const content: DtsContent = await creator.create(f, undefined, !!options.watch);
-            await content.writeFile();
+  const writeFile = async (f: string): Promise<void> => {
+    try {
+      const content: DtsContent = await creator.create(
+        f,
+        undefined,
+        !!options.watch
+      );
+      await content.writeFile();
 
-            if (!options.silent) {
-                console.log('Wrote ' + chalk.green(content.outputFilePath));
-            }
-        }
-        catch (error) {
-            console.error(chalk.red('[Error] ' + error));
-        }
-    };
-
-    if(!options.watch) {
-        const files = await glob(filesPattern);
-        await Promise.all(files.map(writeFile));
-    } else {
-        console.log('Watch ' + filesPattern + '...');
-
-        const watcher = chokidar.watch([filesPattern.replace(/\\/g, "/")]);
-        watcher.on('add', writeFile);
-        watcher.on('change', writeFile);
-        await waitForever();
+      if (!options.silent) {
+        console.log('Wrote ' + chalk.green(content.outputFilePath));
+      }
+    } catch (error) {
+      console.error(chalk.red('[Error] ' + error));
     }
+  };
+
+  if (!options.watch) {
+    const files = await glob(filesPattern);
+    await Promise.all(files.map(writeFile));
+  } else {
+    console.log('Watch ' + filesPattern + '...');
+
+    const watcher = chokidar.watch([filesPattern.replace(/\\/g, '/')]);
+    watcher.on('add', writeFile);
+    watcher.on('change', writeFile);
+    await waitForever();
+  }
 }
 
 async function waitForever(): Promise<void> {
-    return new Promise<void>(() => {});
+  return new Promise<void>(() => {});
 }

--- a/test/kebabed.css
+++ b/test/kebabed.css
@@ -1,4 +1,3 @@
 .my-class {
   color: red;
 }
-

--- a/test/testStyle.css.d.ts
+++ b/test/testStyle.css.d.ts
@@ -1,5 +1,4 @@
 declare const styles: {
-  readonly "myClass": string;
+  readonly myClass: string;
 };
 export = styles;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,14 +718,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
@@ -805,14 +797,6 @@ copy-descriptor@^0.1.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -895,7 +879,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -975,7 +959,7 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-error-ex@^1.2.0, error-ex@^1.3.1:
+error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
@@ -1029,18 +1013,6 @@ esutils@^2.0.2:
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
-
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
 
 execa@^1.0.0:
   version "1.0.0"
@@ -1146,12 +1118,6 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-up@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  dependencies:
-    locate-path "^2.0.0"
-
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -1222,10 +1188,6 @@ gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-
-get-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -1449,10 +1411,6 @@ invariant@^2.2.4:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -2101,12 +2059,6 @@ kleur@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
 
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  dependencies:
-    invert-kv "^1.0.0"
-
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -2128,15 +2080,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-load-json-file@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    strip-bom "^3.0.0"
-
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -2145,13 +2088,6 @@ load-json-file@^4.0.0:
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
-
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -2177,13 +2113,6 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -2217,12 +2146,6 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
-
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  dependencies:
-    mimic-fn "^1.0.0"
 
 mem@^4.0.0:
   version "4.3.0"
@@ -2275,10 +2198,6 @@ mime-types@~2.1.17:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
-
-mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 mimic-fn@^2.0.0:
   version "2.1.0"
@@ -2537,14 +2456,6 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  dependencies:
-    execa "^0.7.0"
-    lcid "^1.0.0"
-    mem "^1.1.0"
-
 os-locale@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
@@ -2582,23 +2493,11 @@ p-is-promise@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
 
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  dependencies:
-    p-try "^1.0.0"
-
 p-limit@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
   dependencies:
     p-try "^2.0.0"
-
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  dependencies:
-    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -2610,19 +2509,9 @@ p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
 
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-
-parse-json@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
-  dependencies:
-    error-ex "^1.2.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -2660,12 +2549,6 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
-path-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
-  dependencies:
-    pify "^2.0.0"
-
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -2675,10 +2558,6 @@ path-type@^3.0.0:
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-
-pify@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
 pify@^3.0.0:
   version "3.0.0"
@@ -2779,10 +2658,6 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -2815,27 +2690,12 @@ react-is@^16.8.4:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
-read-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
-  dependencies:
-    find-up "^2.0.0"
-    read-pkg "^2.0.0"
-
 read-pkg-up@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
   dependencies:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
-
-read-pkg@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
-  dependencies:
-    load-json-file "^2.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^2.0.0"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -3599,17 +3459,9 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
@@ -3628,15 +3480,10 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs@^12.0.2:
+yargs@^12.0.2, yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.2.0"
@@ -3650,21 +3497,3 @@ yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
-
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
-  dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^7.0.0"


### PR DESCRIPTION
Hello! I'm having this issue when running with webpack, it updates the `.d.ts` related files changing the style defined by prettier. This shows a lot of false positives changed files because prettier styles our `.d.ts` files and differs with what the lib does.

In this PR I address this problem.

Thank you for your work!

PS: the gitatribute files and all are because I'm using windows, and had trouble with the EOL's.