### PR TITLE
Improve type definitions output

### DIFF
--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -63,7 +63,8 @@ export class DtsCreator {
 
       const result = keys
         .map(k => convertKey(k))
-        .map(k => 'readonly "' + k + '": string;')
+        .map(k => 'readonly \'' + k + '\': string;')
+      result.sort();
 
       const content = new DtsContent({
         dropExtension: this.dropExtension,


### PR DESCRIPTION
This change accomplishes 2 things:
1) Uses single quotes rather than double quotes, as that matches prettier defaults
2) Sort the output for stability