### PR TITLE
Use <basename> for default export name

### DIFF
--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import isThere from "is-there";
 import * as mkdirp from 'mkdirp';
 import * as util from "util";
+import camelcase from "camelcase";
 
 const writeFile = util.promisify(fs.writeFile);
 
@@ -46,11 +47,12 @@ export class DtsContent {
 
     public get formatted(): string {
         if(!this.resultList || !this.resultList.length) return '';
+        const exportName = this.buildExportName();
         return [
-            'declare const styles: {',
+            `declare const ${exportName}: {`,
             ...this.resultList.map(line => '  ' + line),
             '};',
-            'export = styles;',
+            `export default ${exportName};`,
             ''
         ].join(os.EOL) + this.EOL;
     }
@@ -77,6 +79,16 @@ export class DtsContent {
         }
 
         await writeFile(this.outputFilePath, finalOutput, 'utf8');
+    }
+
+    private buildExportName() {
+        const outputFileNameParts = removeExtension(this.rInputPath).split('/');
+        const outputStyleName = camelcase(
+            outputFileNameParts[outputFileNameParts.length - 1]
+        );
+        return `${outputStyleName.charAt(0).toUpperCase()}${outputStyleName.slice(
+            1
+        )}`;
     }
 }
 

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -104,10 +104,10 @@ describe('DtsContent', () => {
         assert.equal(
           content.formatted,
           `\
-declare const styles: {
+declare const TestStyle: {
   readonly "myClass": string;
 };
-export = styles;
+export default TestStyle;
 
 `
         );
@@ -130,10 +130,10 @@ export = styles;
             assert.equal(
               content.formatted,
               `\
-declare const styles: {
+declare const Kebabed: {
   readonly "myClass": string;
 };
-export = styles;
+export default Kebabed;
 
 `
             );
@@ -148,10 +148,10 @@ export = styles;
             assert.equal(
               content.formatted,
               `\
-declare const styles: {
+declare const KebabedUpperCase: {
   readonly "myClass": string;
 };
-export = styles;
+export default KebabedUpperCase;
 
 `
             );
@@ -166,10 +166,10 @@ export = styles;
             assert.equal(
               content.formatted,
               `\
-declare const styles: {
+declare const KebabedUpperCase: {
   readonly "MyClass": string;
 };
-export = styles;
+export default KebabedUpperCase;
 
 `
             );

--- a/test/testStyle.css.d.ts
+++ b/test/testStyle.css.d.ts
@@ -1,5 +1,5 @@
-declare const styles: {
+declare const TestStyle: {
   readonly "myClass": string;
 };
-export = styles;
+export default TestStyle;
 


### PR DESCRIPTION
Solves => https://github.com/Quramy/typed-css-modules/issues/94

Same purpose as https://github.com/Quramy/typed-css-modules/pull/66 but with the proposed changes coming from https://github.com/Quramy/typed-css-modules/issues/27