### PR TITLE
Do not overwrite files if content is the same

### DIFF
--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -6,7 +6,7 @@ import * as mkdirp from 'mkdirp';
 import * as util from "util";
 
 const writeFile = util.promisify(fs.writeFile);
-
+const readFile = util.promisify(fs.readFile);
 
 interface DtsContentOptions {
     dropExtension: boolean;
@@ -76,7 +76,21 @@ export class DtsContent {
             mkdirp.sync(outPathDir);
         }
 
-        await writeFile(this.outputFilePath, finalOutput, 'utf8');
+        let isDirty = false;
+
+        if(!isThere(this.outputFilePath)) {
+            isDirty = true;
+        } else {
+            const content = (await readFile(this.outputFilePath)).toString();
+
+            if(content !== finalOutput) {
+                isDirty = true;
+            }
+        }
+
+        if(isDirty) {
+            await writeFile(this.outputFilePath, finalOutput, 'utf8');
+        }
     }
 }
 


### PR DESCRIPTION
Hi! Thanks for the great package.

I noticed that output files are being overwritten even if the content is the same. Turns out I'm not the only one who is annoyed by this behavior, so this is the PR that fixes it.

Resolves #44.