### PR TITLE
Add named exports output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ So, you can import CSS modules' class or variable into your TypeScript sources:
 
 ```ts
 /* app.ts */
-import * as styles from './styles.css';
+import styles from './styles.css';
 console.log(`<div class="${styles.myClass}"></div>`);
 console.log(`<div style="color: ${styles.primary}"></div>`);
 ```
@@ -102,10 +102,44 @@ webpack `css-loader`. This will keep upperCase class names intact, e.g.:
 becomes
 
 ```typescript
-export const SomeComponent: string;
+declare const styles: {
+  readonly "SomeComponent": string;
+};
+export = styles;
 ```
 
 See also [webpack css-loader's camelCase option](https://github.com/webpack/css-loader#camelcase).
+
+#### named exports (enable tree shaking)
+With `-e` or `--namedExports`, types are exported as named exports as opposed to default exports.
+This enables support for the `namedExports` css-loader feature, required for webpack to tree shake the final CSS (learn more [here](https://webpack.js.org/loaders/css-loader/#namedexport)).
+
+Use this option in combination with https://webpack.js.org/loaders/css-loader/#namedexport and https://webpack.js.org/loaders/style-loader/#namedexport (if you use `style-loader`).
+
+When this option is enabled, the type definition changes to support named exports.
+
+*NOTE: this option enables camelcase by default.*
+
+```css
+.SomeComponent {
+  height: 10px;
+}
+```
+
+**Standard output:**
+
+```typescript
+declare const styles: {
+  readonly "SomeComponent": string;
+};
+export = styles;
+```
+
+**Named exports output:**
+
+```typescript
+export const someComponent: string;
+```
 
 ## API
 
@@ -133,6 +167,7 @@ You can set the following options:
 * `option.searchDir`: Directory which includes target `*.css` files(default: `'./'`).
 * `option.outDir`: Output directory(default: `option.searchDir`).
 * `option.camelCase`: Camelize CSS class tokens.
+* `option.namedExports`: Use named exports as opposed to default exports to enable tree shaking. Requires `import * as style from './file.module.css';` (default: `false`)
 * `option.EOL`: EOL (end of line) for the generated `d.ts` files. Possible values `'\n'` or `'\r\n'`(default: `os.EOL`).
 
 #### `create(filepath, contents) => Promise(dtsContent)`
@@ -182,7 +217,7 @@ e.g. `['my-class is not valid TypeScript variable name.']`.
 Final output file path.
 
 ## Remarks
-If your input CSS file has the followng class names, these invalid tokens are not written to output `.d.ts` file.
+If your input CSS file has the following class names, these invalid tokens are not written to output `.d.ts` file.
 
 ```css
 /* TypeScript reserved word */

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "tcm": "node ../lib/cli.js -p style01.css",
-    "tcmw": "node ../lib/cli.js -w -p style01.css",
+    "tcm": "node ../lib/cli.js -e -p style01.css",
+    "tcmw": "node ../lib/cli.js -e -w -p style01.css",
     "compile": "npm run tcm && ./node_modules/.bin/tsc -p .",
     "bundle": "npm run compile && ./node_modules/.bin/browserify -o bundle.js -p [ css-modulesify -o bundle.css ] app.js",
     "start": "npm run bundle && node bundle.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ const yarg = yargs.usage('Create .css.d.ts from CSS modules *.css files.\nUsage:
   .alias('o', 'outDir').describe('o', 'Output directory').string("o")
   .alias('w', 'watch').describe('w', 'Watch input directory\'s css files or pattern').boolean('w')
   .alias('c', 'camelCase').describe('c', 'Convert CSS class tokens to camelcase').boolean("c")
+  .alias('e', 'namedExports').describe('e', 'Use named exports as opposed to default exports to enable tree shaking.').boolean("e")
   .alias('d', 'dropExtension').describe('d', 'Drop the input files extension').boolean('d')
   .alias('s', 'silent').describe('s', 'Silent output. Do not show "files written" messages').boolean('s')
   .alias('h', 'help').help('h')
@@ -45,6 +46,7 @@ async function main(): Promise<void> {
     outDir: argv.o,
     watch: argv.w,
     camelCase: argv.c,
+    namedExports: argv.e,
     dropExtension: argv.d,
     silent: argv.s
   });

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,6 +14,7 @@ interface RunOptions {
     outDir?: string;
     watch?: boolean;
     camelCase?: boolean;
+    namedExports?: boolean;
     dropExtension?: boolean;
     silent?: boolean;
 }
@@ -26,6 +27,7 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
         searchDir,
         outDir: options.outDir,
         camelCase: options.camelCase,
+        namedExports: options.namedExports,
         dropExtension: options.dropExtension,
     });
 

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -115,6 +115,32 @@ export = styles;
       });
     });
 
+    it('returns named exports formatted .d.ts string', done => {
+      new DtsCreator({ namedExports: true }).create('test/testStyle.css').then(content => {
+        assert.equal(
+          content.formatted,
+          `\
+export const myClass: string;
+
+`
+        );
+        done();
+      });
+    });
+
+    it('returns camelcase names when using named exports as formatted .d.ts string', done => {
+      new DtsCreator({ namedExports: true }).create('test/kebabedUpperCase.css').then(content => {
+        assert.equal(
+          content.formatted,
+          `\
+export const myClass: string;
+
+`
+        );
+        done();
+      });
+    });
+
     it('returns empty object exportion when the result list has no items', done => {
       new DtsCreator().create('test/empty.css').then(content => {
         assert.equal(content.formatted, '');


### PR DESCRIPTION
This PR adds a `namedExports` option to the cli and the `DtsCreator` class.
This option formats the `.d.ts` output using named exports as opposed to a default export.

## Why

When using css-modules, one of the various advantages is tree shaking offered by webpack or other compilers,
as the system knows first hand what you're using from your imports.

When enabling this css-modules feature (available in webpack's `css-loader` and `style-loader`),
the generated style modules will use named exports. This behaviour is not reflected in this module
as default exports are always used in the generated `.d.ts`.

Related to: https://github.com/Quramy/typed-css-modules/issues/99