### PR TITLE
feat: combine classes from imported styles

### DIFF
--- a/src/file-system-loader.ts
+++ b/src/file-system-loader.ts
@@ -68,8 +68,25 @@ export default class FileSystemLoader {
     }
 
     const { injectableSource, exportTokens } = await this.core.load(source, rootRelativePath, trace, this.fetch.bind(this));
+
+    const re = new RegExp(/@import\s'(\D+?.css)';/, 'gm');
+
+    let importTokens: Core.ExportTokens = {};
+
+    let result;
+
+    while (result = re.exec(injectableSource)) {
+      const importFile = result?.[1];
+
+      if  (importFile)  {
+        const localTokens = await this.fetch(importFile, rootRelativePath, undefined, initialContents);
+
+        Object.assign(importTokens, localTokens);
+      }
+    }
+
     this.sources[trace] = injectableSource;
     this.tokensByFile[fileRelativePath] = exportTokens;
-    return exportTokens;
+    return {...exportTokens, ...importTokens};
   }
 }

--- a/test/combined/combined.css
+++ b/test/combined/combined.css
@@ -1,0 +1,6 @@
+@import './imported.css';
+@import '../composee.css';
+
+.block {
+    display: block;
+}

--- a/test/combined/imported.css
+++ b/test/combined/imported.css
@@ -1,0 +1,3 @@
+.myClass {
+    display: block;
+}

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -51,6 +51,15 @@ describe('DtsCreator', () => {
           done();
         });
     });
+    it('returns DtsContent instance combined css', done => {
+      creator.create('test/combined/combined.css').then(content => {
+          assert.equal(content.contents.length, 3);
+          assert.equal(content.contents[0], 'readonly "block": string;');
+          assert.equal(content.contents[1], 'readonly "myClass": string;');
+          assert.equal(content.contents[2], 'readonly "box": string;');
+          done();
+      });
+    });
   });
 
   describe('#modify path', () => {


### PR DESCRIPTION
Improve fetching function, solve issue where one css style imports another style, but doesn't generate classes of imported style.

This PR solves issue described in the issue below:

https://github.com/Quramy/typed-css-modules/issues/87