### PR TITLE
#78 fix: empty .d.ts files are now valid TS modules

### DIFF
--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -62,7 +62,7 @@ export class DtsContent {
   }
 
   public get formatted(): string {
-    if (!this.resultList || !this.resultList.length) return '';
+    if (!this.resultList || !this.resultList.length) return 'export {};';
 
     if (this.namedExports) {
       return (

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -154,7 +154,7 @@ export const myClass: string;
 
     it('returns empty object exportion when the result list has no items', done => {
       new DtsCreator().create('test/empty.css').then(content => {
-        assert.equal(content.formatted, '');
+        assert.equal(content.formatted, 'export {};');
         done();
       });
     });


### PR DESCRIPTION
#78

In https://github.com/Quramy/typed-css-modules/commit/75846f3e5e9b8f0d4d17bcaef4d142c7c1337af8 an empty .d.ts file was changed from `export default {};` to nothing due to the former not being valid TS from version >2.6.

But the issue after that change, as described in #78 , is that an empty .d.ts file cannot be used in practice when importing, since those would not be valid TS modules.

In this PR I suggest to generate `export {};` for files with no type information. This is both valid TS and makes the file a valid TS module.