### PR TITLE
feat: add new CLI option --listDifferent

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ tcm -p 'src/**/*.icss' .
 
 With `-w` or `--watch`, this CLI watches files in the input directory.
 
+#### validating type files
+
+With `-l` or `--listDifferent`, list any files that are different than those that would be generated.
+If any are different, exit with a status code 1.
+
 #### camelize CSS token
 
 With `-c` or `--camelCase`, kebab-cased CSS classes(such as `.my-class {...}`) are exported as camelized TypeScript varibale name(`export const myClass: string`).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,12 @@ const yarg = yargs
   .alias('o', 'outDir')
   .describe('o', 'Output directory')
   .string('o')
+  .alias('l', 'listDifferent')
+  .describe(
+    'l',
+    'List any files that are different than those that would be generated. If any are different, exit with a status code 1.',
+  )
+  .boolean('l')
   .alias('w', 'watch')
   .describe('w', "Watch input directory's css files or pattern")
   .boolean('w')
@@ -63,5 +69,6 @@ async function main(): Promise<void> {
     namedExports: argv.e,
     dropExtension: argv.d,
     silent: argv.s,
+    listDifferent: argv.l,
   });
 }

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -91,9 +91,13 @@ export class DtsContent {
     return path.join(this.rootDir, this.searchDir, this.rInputPath);
   }
 
+  public get relativeInputFilePath(): string {
+    return path.join(this.searchDir, this.rInputPath);
+  }
+
   public async checkFile(postprocessor = (formatted: string) => formatted): Promise<boolean> {
     if (!isThere(this.outputFilePath)) {
-      console.error(chalk.red(`[ERROR] Type file needs to be generated for '${this.inputFilePath}'`));
+      console.error(chalk.red(`[ERROR] Type file needs to be generated for '${this.relativeInputFilePath}'`));
       return false;
     }
 

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -5,6 +5,7 @@ import isThere from 'is-there';
 import * as mkdirp from 'mkdirp';
 import * as util from 'util';
 import camelcase from 'camelcase';
+import chalk from 'chalk';
 
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
@@ -88,6 +89,22 @@ export class DtsContent {
 
   public get inputFilePath(): string {
     return path.join(this.rootDir, this.searchDir, this.rInputPath);
+  }
+
+  public async checkFile(postprocessor = (formatted: string) => formatted): Promise<boolean> {
+    if (!isThere(this.outputFilePath)) {
+      console.error(chalk.red(`[ERROR] Type file needs to be generated for '${this.inputFilePath}'`));
+      return false;
+    }
+
+    const finalOutput = postprocessor(this.formatted);
+    const fileContent = (await readFile(this.outputFilePath)).toString();
+
+    if (fileContent !== finalOutput) {
+      console.error(chalk.red(`[ERROR] Check type definitions for '${this.outputFilePath}'`));
+      return false;
+    }
+    return true;
   }
 
   public async writeFile(postprocessor = (formatted: string) => formatted): Promise<void> {

--- a/test/different.css
+++ b/test/different.css
@@ -1,0 +1,1 @@
+.myClass {color: red;}

--- a/test/different.css.d.ts
+++ b/test/different.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+  readonly "differentClass": string;
+};
+export = styles;

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 
 import * as assert from 'assert';
 import { DtsCreator } from '../src/dts-creator';
+import SpyInstance = jest.SpyInstance;
 
 describe('DtsCreator', () => {
   var creator = new DtsCreator();
@@ -85,6 +86,15 @@ describe('DtsContent', () => {
     it('returns original CSS file name', done => {
       new DtsCreator().create(path.normalize('test/testStyle.css')).then(content => {
         assert.equal(path.relative(process.cwd(), content.inputFilePath), path.normalize('test/testStyle.css'));
+        done();
+      });
+    });
+  });
+
+  describe('#relativeInputFilePath', () => {
+    it('returns relative original CSS file name', done => {
+      new DtsCreator().create(path.normalize('test/testStyle.css')).then(content => {
+        assert.equal(content.relativeInputFilePath, 'test/testStyle.css');
         done();
       });
     });
@@ -210,12 +220,17 @@ export = styles;
   });
 
   describe('#checkFile', () => {
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(exitCode => {
-      throw new Error(`process.exit: ${exitCode}`);
-    });
+    let mockExit: SpyInstance;
+    let mockConsoleLog: SpyInstance;
+    let mockConsoleError: SpyInstance;
 
-    const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
-    const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+    beforeAll(() => {
+      mockExit = jest.spyOn(process, 'exit').mockImplementation(exitCode => {
+        throw new Error(`process.exit: ${exitCode}`);
+      });
+      mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+      mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+    });
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -3,7 +3,6 @@
 import * as path from 'path';
 
 import * as assert from 'assert';
-import * as os from 'os';
 import { DtsCreator } from '../src/dts-creator';
 
 describe('DtsCreator', () => {
@@ -207,6 +206,61 @@ export = styles;
           done();
         });
       });
+    });
+  });
+
+  describe('#checkFile', () => {
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(exitCode => {
+      throw new Error(`process.exit: ${exitCode}`);
+    });
+
+    const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+    const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+      mockExit.mockRestore();
+      mockConsoleLog.mockRestore();
+      mockConsoleError.mockRestore();
+    });
+
+    it('return false if type file is missing', done => {
+      new DtsCreator()
+        .create('test/empty.css')
+        .then(content => {
+          return content.checkFile();
+        })
+        .then(result => {
+          assert.equal(result, false);
+          done();
+        });
+    });
+
+    it('returns false if type file content is different', done => {
+      new DtsCreator()
+        .create('test/different.css')
+        .then(content => {
+          return content.checkFile();
+        })
+        .then(result => {
+          assert.equal(result, false);
+          done();
+        });
+    });
+
+    it('returns true if type files match', done => {
+      new DtsCreator()
+        .create('test/testStyle.css')
+        .then(content => {
+          return content.checkFile();
+        })
+        .then(result => {
+          assert.equal(result, true);
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
It would be nice to check / validate CSS files whether they have correct type declaration files. Would like to use it in CI pipeline to enforce that correct files are generated.

@Quramy What do you think? 👀 