### PR TITLE
fix: use relativeOutputFilePath instead of outputFilePath

### DIFF
--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -83,8 +83,11 @@ export class DtsContent {
   }
 
   public get outputFilePath(): string {
-    const outputFileName = this.dropExtension ? removeExtension(this.rInputPath) : this.rInputPath;
-    return path.join(this.rootDir, this.outDir, outputFileName + '.d.ts');
+    return path.join(this.rootDir, this.outDir, this.outputFileName);
+  }
+
+  public get relativeOutputFilePath(): string {
+    return path.join(this.outDir, this.outputFileName);
   }
 
   public get inputFilePath(): string {
@@ -105,7 +108,7 @@ export class DtsContent {
     const fileContent = (await readFile(this.outputFilePath)).toString();
 
     if (fileContent !== finalOutput) {
-      console.error(chalk.red(`[ERROR] Check type definitions for '${this.outputFilePath}'`));
+      console.error(chalk.red(`[ERROR] Check type definitions for '${this.relativeOutputFilePath}'`));
       return false;
     }
     return true;
@@ -167,6 +170,11 @@ export class DtsContent {
     return str.replace(/-+(\w)/g, function (match, firstLetter) {
       return firstLetter.toUpperCase();
     });
+  }
+
+  private get outputFileName(): string {
+    const outputFileName = this.dropExtension ? removeExtension(this.rInputPath) : this.rInputPath;
+    return outputFileName + '.d.ts';
   }
 }
 

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -116,6 +116,28 @@ describe('DtsContent', () => {
     });
   });
 
+  describe('#relativeOutputFilePath', () => {
+    it('adds d.ts to the original filename', done => {
+      new DtsCreator().create(path.normalize('test/testStyle.css')).then(content => {
+        assert.equal(
+          path.relative(process.cwd(), content.relativeOutputFilePath),
+          path.normalize('test/testStyle.css.d.ts'),
+        );
+        done();
+      });
+    });
+
+    it('can drop the original extension when asked', done => {
+      new DtsCreator({ dropExtension: true }).create(path.normalize('test/testStyle.css')).then(content => {
+        assert.equal(
+          path.relative(process.cwd(), content.relativeOutputFilePath),
+          path.normalize('test/testStyle.d.ts'),
+        );
+        done();
+      });
+    });
+  });
+
   describe('#formatted', () => {
     it('returns formatted .d.ts string', done => {
       new DtsCreator().create('test/testStyle.css').then(content => {


### PR DESCRIPTION
Thanks a lot @Quramy for quick response! ❤️ 

A follow-up for #179 to fix output file path being logged as absolute when it should be relative like other logged paths.