### PR TITLE
add unlink watch

### DIFF
--- a/src/dts-content.test.ts
+++ b/src/dts-content.test.ts
@@ -204,4 +204,10 @@ export = styles;
       await content.writeFile();
     });
   });
+  describe('#deleteFile', () => {
+    it('delete a file', async () => {
+      const content = await new DtsCreator().create('fixtures/none.css', undefined, false, true);
+      await content.deleteFile();
+    });
+  });
 });

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 
 const writeFile = util.promisify(fs.writeFile);
 const readFile = util.promisify(fs.readFile);
+const unlinkFile = util.promisify(fs.unlink);
 
 export type CamelCaseOption = boolean | 'dashes' | undefined;
 
@@ -138,6 +139,12 @@ export class DtsContent {
 
     if (isDirty) {
       await writeFile(this.outputFilePath, finalOutput, 'utf8');
+    }
+  }
+
+  public async deleteFile() {
+    if (isThere(this.outputFilePath)) {
+      await unlinkFile(this.outputFilePath);
     }
   }
 

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -61,7 +61,6 @@ export class DtsCreator {
     let keys: string[] = [];
     if (!isDelete) {
       const res = await this.loader.fetch(filePath, '/', undefined, initialContents);
-      console.log(res);
       if (!res) throw res;
 
       keys = Object.keys(res);

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -42,7 +42,12 @@ export class DtsCreator {
     this.EOL = options.EOL || os.EOL;
   }
 
-  public async create(filePath: string, initialContents?: string, clearCache: boolean = false): Promise<DtsContent> {
+  public async create(
+    filePath: string,
+    initialContents?: string,
+    clearCache: boolean = false,
+    isDelete: boolean = false,
+  ): Promise<DtsContent> {
     let rInputPath: string;
     if (path.isAbsolute(filePath)) {
       rInputPath = path.relative(this.inputDirectory, filePath);
@@ -53,26 +58,26 @@ export class DtsCreator {
       this.loader.tokensByFile = {};
     }
 
-    const res = await this.loader.fetch(filePath, '/', undefined, initialContents);
-    if (res) {
-      const tokens = res;
-      const keys = Object.keys(tokens);
+    let keys: string[] = [];
+    if (!isDelete) {
+      const res = await this.loader.fetch(filePath, '/');
+      if (!res) throw res;
 
-      const content = new DtsContent({
-        dropExtension: this.dropExtension,
-        rootDir: this.rootDir,
-        searchDir: this.searchDir,
-        outDir: this.outDir,
-        rInputPath,
-        rawTokenList: keys,
-        namedExports: this.namedExports,
-        camelCase: this.camelCase,
-        EOL: this.EOL,
-      });
-
-      return content;
-    } else {
-      throw res;
+      keys = Object.keys(res);
     }
+
+    const content = new DtsContent({
+      dropExtension: this.dropExtension,
+      rootDir: this.rootDir,
+      searchDir: this.searchDir,
+      outDir: this.outDir,
+      rInputPath,
+      rawTokenList: keys,
+      namedExports: this.namedExports,
+      camelCase: this.camelCase,
+      EOL: this.EOL,
+    });
+
+    return content;
   }
 }

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -60,7 +60,8 @@ export class DtsCreator {
 
     let keys: string[] = [];
     if (!isDelete) {
-      const res = await this.loader.fetch(filePath, '/');
+      const res = await this.loader.fetch(filePath, '/', undefined, initialContents);
+      console.log(res);
       if (!res) throw res;
 
       keys = Object.keys(res);

--- a/src/run.ts
+++ b/src/run.ts
@@ -51,6 +51,18 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
     }
   };
 
+  const deleteFile = async (f: string): Promise<void> => {
+    try {
+      const content: DtsContent = await creator.create(f, undefined, !!options.watch, true);
+
+      await content.deleteFile();
+
+      console.log('Delete ' + chalk.green(content.outputFilePath));
+    } catch (error) {
+      console.error(chalk.red('[Error] ' + error));
+    }
+  };
+
   if (options.listDifferent) {
     const files = await glob(filesPattern);
     const hasErrors = (await Promise.all(files.map(checkFile))).includes(false);
@@ -69,6 +81,7 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
     const watcher = chokidar.watch([filesPattern.replace(/\\/g, '/')]);
     watcher.on('add', writeFile);
     watcher.on('change', writeFile);
+    watcher.on('unlink', deleteFile);
     await waitForever();
   }
 }


### PR DESCRIPTION
## Description
When a css file is deleted during watch, the type file is also deleted.
Until now, even after deleting css files, type files often remained, causing confusion.


## Solution
I used chokidar's `watcher.on('unlink')`
https://github.com/paulmillr/chokidar