### PR TITLE
'allowArbitraryExtensions' Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ export = styles;
 export const someComponent: string;
 ```
 
+#### arbitrary file extensions
+
+With `-a` or `--allowArbitraryExtensions`, output filenames will be compatible with the "arbitrary file extensions" feature that was introduce in TypeScript 5.0. See [the docs](https://www.typescriptlang.org/tsconfig#allowArbitraryExtensions) for more info.
+
+In essence, the `*.css.d.ts` extension now becomes `*.d.css.ts` so that you can import CSS modules in projects using ESM module resolution.
+
 ## API
 
 ```sh
@@ -178,6 +184,7 @@ You can set the following options:
 - `option.outDir`: Output directory(default: `option.searchDir`).
 - `option.camelCase`: Camelize CSS class tokens.
 - `option.namedExports`: Use named exports as opposed to default exports to enable tree shaking. Requires `import * as style from './file.module.css';` (default: `false`)
+- `option.allowArbitraryExtensions`: Output filenames that will be compatible with the "arbitrary file extensions" TypeScript feature
 - `option.EOL`: EOL (end of line) for the generated `d.ts` files. Possible values `'\n'` or `'\r\n'`(default: `os.EOL`).
 
 #### `create(filepath, contents) => Promise(dtsContent)`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,11 @@ const yarg = yargs(hideBin(process.argv))
       desc: 'Use named exports as opposed to default exports to enable tree shaking.',
       alias: 'namedExports',
     },
+    a: {
+      type: 'boolean',
+      desc: 'Use the ".d.css.ts" extension to be compatible with the equivalent TypeScript option',
+      alias: 'allowArbitraryExtensions',
+    },
     d: {
       type: 'boolean',
       desc: "'Drop the input files extension'",

--- a/src/dts-content.test.ts
+++ b/src/dts-content.test.ts
@@ -39,6 +39,13 @@ describe('DtsContent', () => {
       const content = await new DtsCreator({ dropExtension: true }).create(path.normalize('fixtures/testStyle.css'));
       assert.equal(path.relative(process.cwd(), content.outputFilePath), path.normalize('fixtures/testStyle.d.ts'));
     });
+
+    it('can comply with TypeScript allowArbitraryExtensions when asked', async () => {
+      const content = await new DtsCreator({ allowArbitraryExtensions: true }).create(
+        path.normalize('fixtures/testStyle.css'),
+      );
+      assert.equal(path.relative(process.cwd(), content.outputFilePath), path.normalize('fixtures/testStyle.d.css.ts'));
+    });
   });
 
   describe('#relativeOutputFilePath', () => {

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -16,6 +16,7 @@ interface DtsContentOptions {
   rInputPath: string;
   rawTokenList: string[];
   namedExports: boolean;
+  allowArbitraryExtensions: boolean;
   camelCase: CamelCaseOption;
   EOL: string;
 }
@@ -28,6 +29,7 @@ export class DtsContent {
   private rInputPath: string;
   private rawTokenList: string[];
   private namedExports: boolean;
+  private allowArbitraryExtensions: boolean;
   private camelCase: CamelCaseOption;
   private resultList: string[];
   private EOL: string;
@@ -40,6 +42,7 @@ export class DtsContent {
     this.rInputPath = options.rInputPath;
     this.rawTokenList = options.rawTokenList;
     this.namedExports = options.namedExports;
+    this.allowArbitraryExtensions = options.allowArbitraryExtensions;
     this.camelCase = options.camelCase;
     this.EOL = options.EOL;
 
@@ -177,8 +180,14 @@ export class DtsContent {
   }
 
   private get outputFileName(): string {
-    const outputFileName = this.dropExtension ? removeExtension(this.rInputPath) : this.rInputPath;
-    return outputFileName + '.d.ts';
+    // Original extension must be dropped when using the allowArbitraryExtensions option
+    const outputFileName =
+      this.dropExtension || this.allowArbitraryExtensions ? removeExtension(this.rInputPath) : this.rInputPath;
+    /**
+     * Handles TypeScript 5.0 addition of arbitrary file extension patterns for ESM compatibility
+     * https://www.typescriptlang.org/tsconfig#allowArbitraryExtensions
+     */
+    return outputFileName + (this.allowArbitraryExtensions ? '.d.css.ts' : '.d.ts');
   }
 }
 

--- a/src/dts-creator.test.ts
+++ b/src/dts-creator.test.ts
@@ -52,4 +52,15 @@ describe(DtsCreator, () => {
       assert.equal(path.relative(process.cwd(), content.outputFilePath), path.normalize('dist/testStyle.css.d.ts'));
     });
   });
+
+  describe('#allow arbitrary extensions', () => {
+    it('can be set allowArbitraryExtensions', async () => {
+      const content = await new DtsCreator({
+        searchDir: 'fixtures',
+        outDir: 'dist',
+        allowArbitraryExtensions: true,
+      }).create(path.normalize('fixtures/testStyle.css'));
+      assert.equal(path.relative(process.cwd(), content.outputFilePath), path.normalize('dist/testStyle.d.css.ts'));
+    });
+  });
 });

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -13,6 +13,7 @@ interface DtsCreatorOptions {
   outDir?: string;
   camelCase?: CamelCaseOption;
   namedExports?: boolean;
+  allowArbitraryExtensions?: boolean;
   dropExtension?: boolean;
   EOL?: string;
   loaderPlugins?: Plugin[];
@@ -26,6 +27,7 @@ export class DtsCreator {
   private inputDirectory: string;
   private camelCase: CamelCaseOption;
   private namedExports: boolean;
+  private allowArbitraryExtensions: boolean;
   private dropExtension: boolean;
   private EOL: string;
 
@@ -38,6 +40,7 @@ export class DtsCreator {
     this.inputDirectory = path.join(this.rootDir, this.searchDir);
     this.camelCase = options.camelCase;
     this.namedExports = !!options.namedExports;
+    this.allowArbitraryExtensions = !!options.allowArbitraryExtensions;
     this.dropExtension = !!options.dropExtension;
     this.EOL = options.EOL || os.EOL;
   }
@@ -74,6 +77,7 @@ export class DtsCreator {
       rInputPath,
       rawTokenList: keys,
       namedExports: this.namedExports,
+      allowArbitraryExtensions: this.allowArbitraryExtensions,
       camelCase: this.camelCase,
       EOL: this.EOL,
     });

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,6 +10,7 @@ interface RunOptions {
   watch?: boolean;
   camelCase?: boolean;
   namedExports?: boolean;
+  allowArbitraryExtensions?: boolean;
   dropExtension?: boolean;
   silent?: boolean;
   listDifferent?: boolean;
@@ -24,6 +25,7 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
     outDir: options.outDir,
     camelCase: options.camelCase,
     namedExports: options.namedExports,
+    allowArbitraryExtensions: options.allowArbitraryExtensions,
     dropExtension: options.dropExtension,
   });
 


### PR DESCRIPTION
Added additional flag to enable compatibility with TypeScript 5.0 'allowArbitraryExtensions' option (see #222 )

Additional TypeScript info: https://www.typescriptlang.org/tsconfig#allowArbitraryExtensions