### PR TITLE
actually map the allowArbitraryExtensions cli argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,6 +89,7 @@ async function main(): Promise<void> {
     camelCase: argv.c,
     namedExports: argv.e,
     dropExtension: argv.d,
+    allowArbitraryExtensions: argv.a,
     silent: argv.s,
     listDifferent: argv.l,
   });


### PR DESCRIPTION
I overlooked the CLI mapping in the `run()` call - this fixes that and properly passes the option