### PR TITLE
Bugfix: Issue #97 - Ignore add/change messages from Chokidar on files that don't match the pattern.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "glob": "^10.3.10",
         "icss-replace-symbols": "^1.1.0",
         "is-there": "^4.4.2",
+        "minimatch": "^9.0.3",
         "mkdirp": "^3.0.0",
         "postcss": "^8.0.0",
         "postcss-modules-extract-imports": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "glob": "^10.3.10",
     "icss-replace-symbols": "^1.1.0",
     "is-there": "^4.4.2",
+    "minimatch": "^9.0.3",
     "mkdirp": "^3.0.0",
     "postcss": "^8.0.0",
     "postcss-modules-extract-imports": "^3.0.0",


### PR DESCRIPTION
tl;dr

* Works around a bug in a dependency
* No change in behavior other than fixing the bug
* No change in API or documentation or examples

[Chokidar has a bug](https://github.com/paulmillr/chokidar/issues/967) where it does not filter paths by the provided pattern if they are inside a symlink. The bug is two years old. 

This PR rechecks the file path against the pattern if we're watching to work around the Chokidar bug.

It adds a dependency on [minimatch](https://www.npmjs.com/package/minimatch) but that dependency already existed via a transient dependency (actually several versions are referenced currently due to already existing incorrect transient dependencies on glob in some reporters). 

Chokidar issue:

  https://github.com/paulmillr/chokidar/issues/967

When that's fixed this PR can be reverted, but the issue is 2 years old already (reported 2020).
