### PR TITLE
fixed TS 5.5 stricter import behavior

### DIFF
--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -72,7 +72,7 @@ export class DtsContent {
     }
 
     return (
-      ['declare const styles: {', ...this.resultList.map(line => '  ' + line), '};', 'export = styles;', ''].join(
+      ['declare const styles: {', ...this.resultList.map(line => '  ' + line), '};', 'export default styles;', ''].join(
         this.EOL,
       ) + this.EOL
     );


### PR DESCRIPTION
This would be a quickfix to change to the default module export style "export default styles" instead of "export = styles"

Not sure if it would be better to add a flag so the user can choose to use module or commonJS style export.